### PR TITLE
[#6] feat: 라우터 구성

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "firebase": "^10.5.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-router-dom": "^6.18.0",
         "react-scripts": "5.0.1",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
@@ -4116,6 +4117,14 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.11.0.tgz",
+      "integrity": "sha512-BHdhcWgeiudl91HvVa2wxqZjSHbheSgIiDvxrF1VjFzBzpTtuDPkOdOi3Iqvc08kXtFkLjhbS+ML9aM8mJS+wQ==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.1",
@@ -16384,6 +16393,36 @@
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.18.0.tgz",
+      "integrity": "sha512-vk2y7Dsy8wI02eRRaRmOs9g2o+aE72YCx5q9VasT1N9v+lrdB79tIqrjMfByHiY5+6aYkH2rUa5X839nwWGPDg==",
+      "dependencies": {
+        "@remix-run/router": "1.11.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.18.0.tgz",
+      "integrity": "sha512-Ubrue4+Ercc/BoDkFQfc6og5zRQ4A8YxSO3Knsne+eRbZ+IepAsK249XBH/XaFuOYOYr3L3r13CXTLvYt5JDjw==",
+      "dependencies": {
+        "@remix-run/router": "1.11.0",
+        "react-router": "6.18.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "firebase": "^10.5.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.18.0",
     "react-scripts": "5.0.1",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"

--- a/src/components/shared/Layout.tsx
+++ b/src/components/shared/Layout.tsx
@@ -1,0 +1,22 @@
+import { Link, Outlet } from 'react-router-dom'
+
+function Layout() {
+  return (
+    <>
+      <nav>
+        <ul>
+          <li>
+            <Link to={'/buckets'}>마이 버킷</Link>
+          </li>
+          <li>
+            <Link to={'/feed'}>피드</Link>
+          </li>
+        </ul>
+      </nav>
+
+      <Outlet />
+    </>
+  )
+}
+
+export default Layout

--- a/src/components/shared/RouteError.tsx
+++ b/src/components/shared/RouteError.tsx
@@ -1,0 +1,30 @@
+import { isRouteErrorResponse, useRouteError } from 'react-router-dom'
+
+function getErrorMessage(error: unknown): string {
+  if (isRouteErrorResponse(error)) {
+    return `${error.status} ${error.statusText}`
+  } else if (error instanceof Error) {
+    return error.message
+  } else if (typeof error === 'string') {
+    return error
+  } else {
+    return 'Unknown error'
+  }
+}
+
+function ErrorPage() {
+  const error = useRouteError()
+  const errorMessage = getErrorMessage(error)
+
+  return (
+    <div>
+      <h1>Oops!</h1>
+      <p>에러가 발생했습니다.</p>
+      <p>
+        <i>{errorMessage}</i>
+      </p>
+    </div>
+  )
+}
+
+export default ErrorPage

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,13 +1,41 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import '@/index.css'
-import App from '@/App'
 import reportWebVitals from '@/reportWebVitals'
+import { RouterProvider, createBrowserRouter } from 'react-router-dom'
+import ErrorPage from './components/shared/RouteError'
+import Layout from './components/shared/Layout'
+
+const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <Layout />,
+    errorElement: <ErrorPage />,
+    children: [
+      {
+        path: 'buckets',
+        element: (
+          <div>
+            <span>Buckets</span>
+          </div>
+        ),
+      },
+      {
+        path: 'feed',
+        element: (
+          <div>
+            <span>Feed</span>
+          </div>
+        ),
+      },
+    ],
+  },
+])
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
 root.render(
   <React.StrictMode>
-    <App />
+    <RouterProvider router={router} />
   </React.StrictMode>,
 )
 


### PR DESCRIPTION
## 구현내용
- react-router-dom 패키지를 추가하고 초기 세팅을 진행했습니다.
- 라우터 루트에 서비스 전체에 활용할 Layout을 구현했습니다. (navigation bar가 위치함)

## 특이사항
- 지난번 미팅 때 알려주신 Route 컴포넌트를 활용한 방식이 아닌 `RouterProvider` 방식을 활용했습니다. (v6 이후 신 기능)
  - 해당 방식이 등장한 배경은 이전 방식은 라우팅 설정을 컴포넌트를 중첩해서 선언하는 방식으로 큰 규모의 애플리케이션에서 라우팅 구조를 관리하고 이해하는데 어려움을 겪었기 때문이라고 합니다.
  - 그리고 라우트 레벨에서 코드 스플리팅을 쉽게 구현할 수 있도록 설계되었다고 합니다.
  - 참고자료
    - https://reactrouter.com/en/main/start/tutorial
    - https://reactrouter.com/en/main/upgrading/v6-data#migrating-to-routerprovider
    - https://github.com/remix-run/react-router/discussions/9628#discussioncomment-5555901