### PR TITLE
[#25] 인증 상태에 따른 렌더링 구현

### DIFF
--- a/src/components/auth/AuthGuard.tsx
+++ b/src/components/auth/AuthGuard.tsx
@@ -1,13 +1,14 @@
-import { useEffect } from 'react'
+import { useContext, useEffect, useState } from 'react'
 
 import { onAuthStateChanged } from 'firebase/auth'
 
-import { useAuth } from '@/hooks/useAuth'
 import { auth } from '@/remote/firebase'
 import Loading from '../shared/Loading'
+import { AuthContext } from '@/context/AuthProvider'
 
 function AuthGuard({ children }: { children: React.ReactNode }) {
-  const { initialized, setUser, setInitialized } = useAuth()
+  const { setUser } = useContext(AuthContext)
+  const [initialized, setInitialized] = useState(false)
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, (currentUser) => {

--- a/src/components/auth/AuthGuard.tsx
+++ b/src/components/auth/AuthGuard.tsx
@@ -1,8 +1,24 @@
+import { useEffect } from 'react'
+
+import { onAuthStateChanged } from 'firebase/auth'
+
 import { useAuth } from '@/hooks/useAuth'
+import { auth } from '@/remote/firebase'
 import Loading from '../shared/Loading'
 
 function AuthGuard({ children }: { children: React.ReactNode }) {
-  const { initialized } = useAuth()
+  const { initialized, setUser, setInitialized } = useAuth()
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
+      setUser(currentUser)
+      setInitialized(true)
+    })
+
+    return () => {
+      unsubscribe()
+    }
+  }, [setInitialized, setUser])
 
   if (initialized === false) {
     return <Loading />

--- a/src/components/auth/AuthGuard.tsx
+++ b/src/components/auth/AuthGuard.tsx
@@ -1,0 +1,14 @@
+import { useAuth } from '@/hooks/useAuth'
+import Loading from '../shared/Loading'
+
+function AuthGuard({ children }: { children: React.ReactNode }) {
+  const { initialized } = useAuth()
+
+  if (initialized === false) {
+    return <Loading />
+  }
+
+  return <>{children}</>
+}
+
+export default AuthGuard

--- a/src/components/shared/Layout.tsx
+++ b/src/components/shared/Layout.tsx
@@ -1,6 +1,9 @@
 import { Link, Outlet } from 'react-router-dom'
+import SignOut from './SignOut'
+import { useAuth } from '@/hooks/useAuth'
 
 function Layout() {
+  const { user } = useAuth()
   return (
     <>
       <nav>
@@ -10,6 +13,9 @@ function Layout() {
           </li>
           <li>
             <Link to={'/feed'}>피드</Link>
+          </li>
+          <li>
+            {user ? <SignOut /> : <Link to={'/signin'}>로그인/회원가입</Link>}
           </li>
         </ul>
       </nav>

--- a/src/components/shared/Layout.tsx
+++ b/src/components/shared/Layout.tsx
@@ -1,9 +1,10 @@
 import { Link, Outlet } from 'react-router-dom'
 import SignOut from './SignOut'
-import { useAuth } from '@/hooks/useAuth'
+import { useContext } from 'react'
+import { AuthContext } from '@/context/AuthProvider'
 
 function Layout() {
-  const { user } = useAuth()
+  const { user } = useContext(AuthContext)
   return (
     <>
       <nav>

--- a/src/components/shared/Layout.tsx
+++ b/src/components/shared/Layout.tsx
@@ -1,10 +1,11 @@
 import { Link, Outlet } from 'react-router-dom'
+
 import SignOut from './SignOut'
-import { useContext } from 'react'
-import { AuthContext } from '@/context/AuthProvider'
+import { useUser } from '@/hooks/useUser'
 
 function Layout() {
-  const { user } = useContext(AuthContext)
+  const user = useUser()
+
   return (
     <>
       <nav>

--- a/src/components/shared/SignOut.tsx
+++ b/src/components/shared/SignOut.tsx
@@ -1,0 +1,22 @@
+import { signOut } from 'firebase/auth'
+import { useNavigate } from 'react-router-dom'
+
+import { auth } from '@/remote/firebase'
+import { useCallback } from 'react'
+
+function SignOut() {
+  const navigate = useNavigate()
+
+  const handleSignOut = useCallback(async () => {
+    try {
+      await signOut(auth)
+
+      navigate('/signin')
+    } catch (error) {
+      console.error('로그아웃을 다시 시도해 주세요.', error)
+    }
+  }, [navigate])
+  return <button onClick={handleSignOut}>로그아웃</button>
+}
+
+export default SignOut

--- a/src/components/test/LoginButton.tsx
+++ b/src/components/test/LoginButton.tsx
@@ -1,0 +1,17 @@
+import { auth } from '@/remote/firebase'
+import { signInWithEmailAndPassword } from 'firebase/auth'
+import { useNavigate } from 'react-router-dom'
+
+function LoginButton() {
+  const navigate = useNavigate()
+  const handleLogin = async () => {
+    const email = 'bucket@bucket.com'
+    const password = '12345678'
+
+    await signInWithEmailAndPassword(auth, email, password)
+    navigate('/buckets')
+  }
+  return <button onClick={handleLogin}>로그인</button>
+}
+
+export default LoginButton

--- a/src/context/AuthProvider.tsx
+++ b/src/context/AuthProvider.tsx
@@ -4,26 +4,19 @@ import { User } from 'firebase/auth'
 
 interface AuthContextType {
   user: User | null
-  initialized: boolean
   setUser: Dispatch<SetStateAction<User | null>>
-  setInitialized: Dispatch<SetStateAction<boolean>>
 }
 
 export const AuthContext = createContext<AuthContextType>({
   user: null,
-  initialized: false,
   setUser: () => {},
-  setInitialized: () => {},
 })
 
 function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null)
-  const [initialized, setInitialized] = useState(false)
 
   return (
-    <AuthContext.Provider
-      value={{ user, initialized, setUser, setInitialized }}
-    >
+    <AuthContext.Provider value={{ user, setUser }}>
       {children}
     </AuthContext.Provider>
   )

--- a/src/context/AuthProvider.tsx
+++ b/src/context/AuthProvider.tsx
@@ -1,36 +1,29 @@
-import { createContext, useEffect, useState } from 'react'
+import { Dispatch, SetStateAction, createContext, useState } from 'react'
 
-import { User, onAuthStateChanged } from 'firebase/auth'
-
-import { auth } from '@/remote/firebase'
+import { User } from 'firebase/auth'
 
 interface AuthContextType {
   user: User | null
   initialized: boolean
+  setUser: Dispatch<SetStateAction<User | null>>
+  setInitialized: Dispatch<SetStateAction<boolean>>
 }
 
 export const AuthContext = createContext<AuthContextType>({
   user: null,
   initialized: false,
+  setUser: () => {},
+  setInitialized: () => {},
 })
 
 function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null)
   const [initialized, setInitialized] = useState(false)
 
-  useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
-      setUser(currentUser)
-      setInitialized(true)
-    })
-
-    return () => {
-      unsubscribe()
-    }
-  }, [])
-
   return (
-    <AuthContext.Provider value={{ user, initialized }}>
+    <AuthContext.Provider
+      value={{ user, initialized, setUser, setInitialized }}
+    >
       {children}
     </AuthContext.Provider>
   )

--- a/src/context/AuthProvider.tsx
+++ b/src/context/AuthProvider.tsx
@@ -1,0 +1,39 @@
+import { createContext, useEffect, useState } from 'react'
+
+import { User, onAuthStateChanged } from 'firebase/auth'
+
+import { auth } from '@/remote/firebase'
+
+interface AuthContextType {
+  user: User | null
+  initialized: boolean
+}
+
+export const AuthContext = createContext<AuthContextType>({
+  user: null,
+  initialized: false,
+})
+
+function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<User | null>(null)
+  const [initialized, setInitialized] = useState(false)
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
+      setUser(currentUser)
+      setInitialized(true)
+    })
+
+    return () => {
+      unsubscribe()
+    }
+  }, [])
+
+  return (
+    <AuthContext.Provider value={{ user, initialized }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export default AuthProvider

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -1,0 +1,8 @@
+import { useContext } from 'react'
+
+import { AuthContext } from '@/context/AuthProvider'
+
+export const useAuth = () => {
+  const auth = useContext(AuthContext)
+  return auth
+}

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -1,7 +1,0 @@
-import { useContext } from 'react'
-
-import { AuthContext } from '@/context/AuthProvider'
-
-export const useAuth = () => {
-  return useContext(AuthContext)
-}

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -3,6 +3,5 @@ import { useContext } from 'react'
 import { AuthContext } from '@/context/AuthProvider'
 
 export const useAuth = () => {
-  const auth = useContext(AuthContext)
-  return auth
+  return useContext(AuthContext)
 }

--- a/src/hooks/useUser.tsx
+++ b/src/hooks/useUser.tsx
@@ -1,0 +1,7 @@
+import { AuthContext } from '@/context/AuthProvider'
+import { useContext } from 'react'
+
+export const useUser = () => {
+  const { user } = useContext(AuthContext)
+  return user
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,9 @@ import Layout from './components/shared/Layout'
 import HomePage from './pages/Home'
 import TestPage from './pages/Test'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import SignInPage from './pages/SignIn'
+import AuthGuard from './components/auth/AuthGuard'
+import AuthProvider from './context/AuthProvider'
 
 const router = createBrowserRouter([
   {
@@ -18,6 +21,10 @@ const router = createBrowserRouter([
       {
         path: '',
         element: <HomePage />,
+      },
+      {
+        path: 'signin',
+        element: <SignInPage />,
       },
       {
         path: 'buckets',
@@ -49,7 +56,11 @@ const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
 root.render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
+      <AuthProvider>
+        <AuthGuard>
+          <RouterProvider router={router} />
+        </AuthGuard>
+      </AuthProvider>
     </QueryClientProvider>
   </React.StrictMode>,
 )

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -1,0 +1,5 @@
+function SignIn() {
+  return <div>SignIn</div>
+}
+
+export default SignIn

--- a/src/pages/Test.tsx
+++ b/src/pages/Test.tsx
@@ -1,9 +1,11 @@
+import LoginButton from '@/components/test/LoginButton'
 import { AddBucketDataButton } from '../components/test/AddBucketDataButton'
 
 function TestPage() {
   return (
     <div>
       <AddBucketDataButton />
+      <LoginButton />
     </div>
   )
 }


### PR DESCRIPTION
## 구현내용
- `onAuthStateChanged`를 사용해 인증 상태를 확인하고 상태에 따라 알맞게 렌더링 되도록 구현
  - 로그인 상황(user 정보가 있을 때)는 Layout에 로그아웃 버튼이 보이고, 
  - 로그아웃 된 상황일 때는 로그인/회원가입 페이지로 이동할 수 있도록 구현
  - redirect 되고, user 정보가 들어오기 전엔(구글 로그인의 경우) 로딩 페이지가 보이도록 구현
- 로그인 한 유저 정보는 계속 활용 되기 때문에 AuthContext에 저장해 활용할 수 있게 함
- SignIn의 경우 epic/login에서 구현하고 있어 테스트를 위한 로그인 버튼을 구현함

## 스크린샷
![ezgif-4-fe4a7d99f3](https://github.com/moim2024/thanks-bucket/assets/77879633/c1d51187-b05e-4cfd-bafb-569c56b83d52)


### 피드백 받고 싶은 점
- user 정보에 따라 Layout에서 다른 정보가 보여야 하는데, 이 부분을 context API로 해결하는 게 맞는 지 궁금합니다.